### PR TITLE
feat: Add HID Support Series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ crashlytics-build.properties
 /[Aa]ssets/[Ss]treamingAssets/aa/*
 
 # misc
+.vscode/
 .DS_Store

--- a/Assets/Packages.meta
+++ b/Assets/Packages.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: df0acd7bbcc4bd043945b21b4e44ce08
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/manifest.json.meta
+++ b/Assets/Packages/manifest.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e5c6c270507011446a19f403aaa7424a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Packages/packages-lock.json.meta
+++ b/Assets/Packages/packages-lock.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0f64177e36d70104883cd32e608537c3
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs.meta
+++ b/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71db68904a49a4e408568fd4b87e8185
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/HIDExpressionManager.meta
+++ b/Assets/Prefabs/HIDExpressionManager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 898a668a0be245240a906e5f83af0704
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/HIDExpressionManager/HIDExpressionManager.prefab
+++ b/Assets/Prefabs/HIDExpressionManager/HIDExpressionManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8454356771357437779
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6742224056409039393}
+  - component: {fileID: 6640217018595127762}
+  m_Layer: 0
+  m_Name: HIDExpressionManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6742224056409039393
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8454356771357437779}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6640217018595127762
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8454356771357437779}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e24f4809835615458f20d653de98164, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/HIDExpressionManager/HIDExpressionManager.prefab.meta
+++ b/Assets/Prefabs/HIDExpressionManager/HIDExpressionManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7553b7d52b7743e4d85389d6d5cf2078
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/CameraController.cs
+++ b/Assets/Script/CameraController.cs
@@ -31,6 +31,11 @@ public class CameraController : MonoBehaviour {
 
     void FixedUpdate()
     {
+        if (!HIDExpressionManagement.instance.isCursorFocusMode)
+        {
+            return;
+        }
+        
         HandleCameraRotation();
 
         Vector3 desiredPosition = CalculateDesiredCameraPosition();

--- a/Assets/Script/classes.meta
+++ b/Assets/Script/classes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fd2c5c8a3622464bb1c03a7b6177c84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/controllers.meta
+++ b/Assets/Script/classes/controllers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f7c80eae4276b54fb8c94ff2a90a86c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/controllers/HIDExpressionManagement.cs
+++ b/Assets/Script/classes/controllers/HIDExpressionManagement.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class HIDExpressionManagement
+{
+    private HIDExpressionManagement() {}
+    public static HIDExpressionManagement instance = new HIDExpressionManagement();
+    public bool isCursorFocusMode { get; private set; } = true;
+
+    public void SetCursorFocusMode(bool isCursorFocusMode)
+    {
+        this.isCursorFocusMode = isCursorFocusMode;
+        ExecuteEachFrame();
+    }
+
+    public void ExecuteEachFrame()
+    {
+        if (Cursor.visible == isCursorFocusMode) {
+            Cursor.visible = !isCursorFocusMode;
+            Cursor.lockState = isCursorFocusMode ? CursorLockMode.Locked : CursorLockMode.None;
+        }
+    }
+}

--- a/Assets/Script/classes/controllers/HIDExpressionManagement.cs
+++ b/Assets/Script/classes/controllers/HIDExpressionManagement.cs
@@ -1,17 +1,35 @@
 using UnityEngine;
 
+/// <summary>
+/// HID 장치와의 상호작용, 입출력 상황을 화면에 표현하기 위해 필요한 기능을 제공합니다.
+/// </summary>
 public class HIDExpressionManagement
 {
     private HIDExpressionManagement() {}
     public static HIDExpressionManagement instance = new HIDExpressionManagement();
     public bool isCursorFocusMode { get; private set; } = true;
 
+    /// <summary>
+    /// 커서 포커스 모드를 활성화하거나 비활성화합니다.
+    /// </summary>
+    /// <param name="isCursorFocusMode">커서 포커스 모드 여부</param>
     public void SetCursorFocusMode(bool isCursorFocusMode)
     {
         this.isCursorFocusMode = isCursorFocusMode;
         ExecuteEachFrame();
     }
 
+    /// <summary>
+    /// 매 프레임마다 <c>HIDExpressionManagement</c>가 관리하는 HID 표현 상태를 설정에 따라 조정합니다. <br />
+    /// <c>HIDExpressionManagement</c>를 사용하고자 한다면, 이 메서드는 반드시 매 프레임마다 호출해야 합니다. <br />
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// void Update() {
+    ///     HIDExpressionManagement.instance.ExecuteEachFrame();
+    /// }
+    /// </code>
+    /// </example>
     public void ExecuteEachFrame()
     {
         if (Cursor.visible == isCursorFocusMode) {

--- a/Assets/Script/classes/controllers/HIDExpressionManagement.cs.meta
+++ b/Assets/Script/classes/controllers/HIDExpressionManagement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 81eea3942640ca84a85955225951ea96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/controllers/HIDExpressionManager.cs
+++ b/Assets/Script/classes/controllers/HIDExpressionManager.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class HIDExpressionManager : MonoBehaviour
+{
+    HIDExpressionManagement hidExpressionManagement = HIDExpressionManagement.instance;
+    HIDInteractionInvokerConfig keyConfig = HIDInteractionInvokerConfigHolder.instance.config;
+
+    void Update()
+    {
+        bool isActiveFocusModeInThisFrame = hidExpressionManagement.isCursorFocusMode;
+        if (hidExpressionManagement.isCursorFocusMode)
+        {
+            foreach (KeyCode each in keyConfig.keyHoldDisableCursorFocusMode)
+            {
+                if (Input.GetKey(each))
+                {
+                    isActiveFocusModeInThisFrame = false;
+                    break;
+                }
+            }
+            foreach (KeyCode each in keyConfig.keyToggleDisableCursorFocusMode)
+            {
+                if (Input.GetKeyDown(each))
+                {
+                    isActiveFocusModeInThisFrame = false;
+                    break;
+                }
+            }
+        }
+
+        foreach (KeyCode each in keyConfig.keyToggleEnableCursorFocusMode)
+        {
+            if (Input.GetKeyDown(each))
+            {
+                isActiveFocusModeInThisFrame = true;
+                break;
+            }
+        }
+        
+        hidExpressionManagement.SetCursorFocusMode(isActiveFocusModeInThisFrame);
+
+        hidExpressionManagement.ExecuteEachFrame();
+    }
+}

--- a/Assets/Script/classes/controllers/HIDExpressionManager.cs
+++ b/Assets/Script/classes/controllers/HIDExpressionManager.cs
@@ -1,5 +1,9 @@
 using UnityEngine;
 
+/// <summary>
+/// HID 장치와의 상호작용, 입출력 상황을 화면에 표현하기 위해 필요한 기능을 제공합니다.
+/// HID 장치와의 상호작용이 발생했을 때, 상호작용 이벤트를 핸들링하고 <c>HIDExpressionManagement</c>에게 이벤트 처리 결과를 전달합니다.
+/// </summary>
 public class HIDExpressionManager : MonoBehaviour
 {
     HIDExpressionManagement hidExpressionManagement = HIDExpressionManagement.instance;
@@ -8,6 +12,7 @@ public class HIDExpressionManager : MonoBehaviour
     void Update()
     {
         bool isActiveFocusModeInThisFrame = hidExpressionManagement.isCursorFocusMode;
+        // 잠재적인 성능 이슈 우려: 포커스모드가 활성화되어있지 않으면 비활성화 키를 평가하지 않음
         if (hidExpressionManagement.isCursorFocusMode)
         {
             foreach (KeyCode each in keyConfig.keyHoldDisableCursorFocusMode)
@@ -38,7 +43,6 @@ public class HIDExpressionManager : MonoBehaviour
         }
         
         hidExpressionManagement.SetCursorFocusMode(isActiveFocusModeInThisFrame);
-
         hidExpressionManagement.ExecuteEachFrame();
     }
 }

--- a/Assets/Script/classes/controllers/HIDExpressionManager.cs.meta
+++ b/Assets/Script/classes/controllers/HIDExpressionManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e24f4809835615458f20d653de98164
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/models.meta
+++ b/Assets/Script/classes/models.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f079ceeb79d4c744a274c91b2c9c027
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs
+++ b/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public struct HIDInteractionInvokerConfig {
+    public List<KeyCode> keyToggleDisableCursorFocusMode { get; set; }
+    public List<KeyCode> keyToggleEnableCursorFocusMode { get; set; }
+    public List<KeyCode> keyHoldDisableCursorFocusMode { get; set; }
+    public HIDInteractionInvokerConfig(
+        KeyCode[] keyToggleDisableCursorFocusMode,
+        KeyCode[] keyToggleEnableCursorFocusMode,
+        KeyCode[] keyHoldDisableCursorFocusMode
+    ) {
+        this.keyToggleDisableCursorFocusMode = keyToggleDisableCursorFocusMode != null ? new List<KeyCode>(keyToggleDisableCursorFocusMode) : new List<KeyCode>(HIDInteractionInvokerDefaults.DEFAULT_KEY_TOGGLE_DISABLE_CURSOR_FOCUS_MODE);
+        this.keyToggleEnableCursorFocusMode = keyToggleEnableCursorFocusMode != null ? new List<KeyCode>(keyToggleEnableCursorFocusMode) : new List<KeyCode>(HIDInteractionInvokerDefaults.DEFAULT_KEY_TOGGLE_ENABLE_CURSOR_FOCUS_MODE);
+        this.keyHoldDisableCursorFocusMode = keyHoldDisableCursorFocusMode != null ? new List<KeyCode>(keyHoldDisableCursorFocusMode) : new List<KeyCode>(HIDInteractionInvokerDefaults.DEFAULT_KEY_HOLD_DISABLE_CURSOR_FOCUS_MODE);
+    }
+}
+
+public class HIDInteractionInvokerConfigHolder {
+    // Todo: Setter must be implemented later.
+    public HIDInteractionInvokerConfig config { get; private set; }
+
+    private HIDInteractionInvokerConfigHolder() {
+        this.config = new HIDInteractionInvokerConfig(
+            HIDInteractionInvokerDefaults.DEFAULT_KEY_TOGGLE_DISABLE_CURSOR_FOCUS_MODE,
+            HIDInteractionInvokerDefaults.DEFAULT_KEY_TOGGLE_ENABLE_CURSOR_FOCUS_MODE,
+            HIDInteractionInvokerDefaults.DEFAULT_KEY_HOLD_DISABLE_CURSOR_FOCUS_MODE
+        );
+    }
+
+    public static HIDInteractionInvokerConfigHolder instance = new HIDInteractionInvokerConfigHolder();
+}

--- a/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs
+++ b/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs
@@ -3,11 +3,26 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+/// <summary>
+/// HID와의 상호작용 발생에 의존하는 이벤트에 대해서, 이벤트를 발생시키는 HID와의 상호작용 유형을 정의합니다.
+/// 이 구조체는 추후에 직렬화할 수 있도록 고려되었습니다.
+/// </summary>
 [Serializable]
 public struct HIDInteractionInvokerConfig {
     public List<KeyCode> keyToggleDisableCursorFocusMode { get; set; }
     public List<KeyCode> keyToggleEnableCursorFocusMode { get; set; }
     public List<KeyCode> keyHoldDisableCursorFocusMode { get; set; }
+
+    /// <summary>
+    /// HIDInteractionInvokerConfig의 인스턴스를 생성합니다.
+    /// 최초 의도는 자동으로 기본값을 불러오도록 하여 매개 변수 없는 생성자를 하는 것이었으나,
+    /// 유니티의 C# 버전이 낮아서 구현할 수 없어 매개 변수를 추가한 생성자를 사용하도록 변경되었습니다.
+    /// 따라서 의도대로 작동하려면 생성자를 호출할 때 기본값 데이터를 매개변수로 전달해야합니다.
+    /// 혹은 매개변수 필드를 전부 null로 설정하도록 작성해도 됩니다.
+    /// </summary>
+    /// <param name="keyToggleDisableCursorFocusMode"></param>
+    /// <param name="keyToggleEnableCursorFocusMode"></param>
+    /// <param name="keyHoldDisableCursorFocusMode"></param>
     public HIDInteractionInvokerConfig(
         KeyCode[] keyToggleDisableCursorFocusMode,
         KeyCode[] keyToggleEnableCursorFocusMode,
@@ -19,8 +34,14 @@ public struct HIDInteractionInvokerConfig {
     }
 }
 
+/// <summary>
+/// HIDInteractionInvokerConfig를 생성하고 관리하는 클래스입니다.
+/// HIDInteractionInvokerConfig를 사용하고자 한다면, 이 클래스의 인스턴스를 사용하세요.
+/// </summary>
 public class HIDInteractionInvokerConfigHolder {
     // Todo: Setter must be implemented later.
+    // HIDInteractionInvokerConfig의 세터가 private로 지정되어있습니다.
+    // 이후에 세터를 추가할 수 있도록 의도된 것이나, 상황에 따라 public으로 변경하는 것도 고려하세요.
     public HIDInteractionInvokerConfig config { get; private set; }
 
     private HIDInteractionInvokerConfigHolder() {

--- a/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs.meta
+++ b/Assets/Script/classes/models/HIDInteractionInvokerConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00baa9499f9138340aa793e924da989f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs
+++ b/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs
@@ -1,5 +1,8 @@
 using UnityEngine;
 
+/// <summary>
+/// HIDInteractionInvokerConfig의 기본값을 정의합니다.
+/// </summary>
 public static class HIDInteractionInvokerDefaults {
     public static readonly KeyCode[] DEFAULT_KEY_TOGGLE_DISABLE_CURSOR_FOCUS_MODE = { KeyCode.Escape };
     public static readonly KeyCode[] DEFAULT_KEY_TOGGLE_ENABLE_CURSOR_FOCUS_MODE = { KeyCode.Mouse0 };

--- a/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs
+++ b/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+public static class HIDInteractionInvokerDefaults {
+    public static readonly KeyCode[] DEFAULT_KEY_TOGGLE_DISABLE_CURSOR_FOCUS_MODE = { KeyCode.Escape };
+    public static readonly KeyCode[] DEFAULT_KEY_TOGGLE_ENABLE_CURSOR_FOCUS_MODE = { KeyCode.Mouse0 };
+    public static readonly KeyCode[] DEFAULT_KEY_HOLD_DISABLE_CURSOR_FOCUS_MODE = { KeyCode.LeftAlt };
+}

--- a/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs.meta
+++ b/Assets/Script/classes/models/HIDInteractionInvokerDefaults.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 614cd9edfd71a3544aea40cba2297863
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/nollegi.unity
+++ b/Assets/nollegi.unity
@@ -2621,6 +2621,7 @@ GameObject:
   - component: {fileID: 1577162125}
   - component: {fileID: 1577162126}
   - component: {fileID: 1577162127}
+  - component: {fileID: 1577162128}
   m_Layer: 0
   m_Name: GameManager
   m_TagString: Untagged
@@ -2762,9 +2763,21 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1577162117}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 339db1472b5106d48a1f772343860239, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1577162128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1577162117}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e24f4809835615458f20d653de98164, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &1622364275

--- a/Documentations/hid-support-family.md
+++ b/Documentations/hid-support-family.md
@@ -1,0 +1,47 @@
+----
+title: "HID Support Family"
+tags: ["hid"]
+relates: ["prefab:HIDExpressionManager", "script:controllers/HIDExpressionManagement", "script:models/HIDInteractionInvokerDefaults", "script:models/InteractionKeyConfig"]
+----
+
+HID 지원을 위한 코드 시리즈입니다.
+
+## 배경
+
+이 코드 시리즈는 커밋 및 PR 당시 마우스의 포커스 설정/해제를 지원하기 위해 작성되었습니다. 이 과정에서 포커스 모드를 전환하는 키의 입력을 감지하고, 포커스 모드의 상태를 관리하며, 전역에서 참조 가능한 관리자의 기능이 필요했습니다.  
+
+일련의 기능을 대응하고 확장성을 갖추기 위해 모든 HID 및 입력 이벤트를 지원 가능하게 확장할 수 있도록(_다시 말해 실제로는 구현되지 않았습니다._) 이 코드를 추가하였습니다.
+
+## 설계
+
+### 키 이벤트 및 상태 관리
+
+HID 이벤트로서 발생하는 상태는 `HIDExpressionManagement`가 관리합니다. 예를 들어, 포커스 모드의 최종 상태는 이 클래스가 관리하며, 다른 코드에서 이 클래스를 통해 상태를 참조할 수 있습니다.  
+_이 클래스는 싱글톤 객체를 자동 생성하므로, 실제로는 싱글톤 객체를 통해 참조합니다._  
+```cs
+HIDExpressionManagement.instance;
+```
+
+하지만 `HIDExpressionManagement`는 상태 데이터를 관리하는 데 집중하므로, 각 상태에 따른 대응은 `HIDExpressionManager`가 수행합니다. 다시 말해 `HIDExpressionMangement`는 데이터 스토리지이고, `HIDExpressionManager`는 핸들러에 가깝습니다.
+
+### 키 설정값 관리
+
+`HIDExpressionManager`가 HID 입력 이벤트를 감지하는데 활용할 데이터로 `HIDInteractionInvokerConfig`, `HIDInteractionInvokerConfigHolder`가 있습니다. `HIDInteractionInvokerConfig`는 소위 말해, 키 세팅을 지원하기 위한 구조체입니다.  
+
+하지만 `HIDInteractionInvokerConfig`는 구조체이므로, 전역적으로 참조하기 위해 `HIDInteractionConfigHolder`의 싱글톤 객체를 사용해야 합니다.
+
+실제로는 아래와 같이 `HIDInteractionInvokerConfig`를 호출할 수 있습니다.
+```cs
+HIDInteractionInvokerConfigHolder.instance;
+```
+
+이와 같이 구조체와 객체를 구분함으로서, 직렬화할 키 세팅 필드의 범위를 명확하게 구분할 수 있습니다. 이후에 키 세팅 필드를 직렬화 하는 방향으로 개발이 진행된다면, `HIDInteractionInvokerConfig`만을 직렬화하면 됩니다.  
+_최초 커밋 시점에서는 이미 `HIDInteractionInvokerConfig`에 `[Serializable]` 처리를 해두었습니다._
+
+최초 커밋 시점의 코드 기준으로, `HIDInteractionInvokerConfig`의 값은 `HIDInteractionInvokerDefaults`에 의해 결정됩니다. _만약 이후에 키 세팅을 저장하고 로드할 수 있도록 개발이 진행된다면, `HIDInteractionInvokerConfig`는 세팅이 제대로 로드되지 않을 때에만 사용할 수 있도록 수정되어야 합니다._
+
+## HIDExpressionManager 프리팹
+
+`HIDExpressionManager` 클래스를 실제로 사용하는 방법 중 하나로서 추가하였습니다.  
+
+_하지만 파라미터 설정이 존재하지 않으므로, 실제로는 게임 오브젝트 컴포넌트로서 등록하기만 하면 됩니다._

--- a/ProjectSettings/TimelineSettings.asset
+++ b/ProjectSettings/TimelineSettings.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &1
+MonoBehaviour:
+  m_ObjectHideFlags: 53
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a287be6c49135cd4f9b2b8666c39d999, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assetDefaultFramerate: 60
+  m_DefaultFrameRate: 60


### PR DESCRIPTION
오늘(8일 저녁) 회의 중 이야기 나왔던 커서 고정 코드의 구현체입니다.

커서 고정 코드를 구현하면서, 키 설정의 일괄 관리를 위해 키 설정 지원 클래스와 부속 코드도 함께 작성했습니다.

자세한 구현 내용은 `/Documentations/hid-support-family.md`를 참조하세요.


<summary>

`/Documentations/hid-support-family.md`

<details>
---

HID 지원을 위한 코드 시리즈입니다.  

## 배경

이 코드 시리즈는 커밋 및 PR 당시 마우스의 포커스 설정/해제를 지원하기 위해 작성되었습니다. 이 과정에서 포커스 모드를 전환하는 키의 입력을 감지하고, 포커스 모드의 상태를 관리하며, 전역에서 참조 가능한 관리자의 기능이 필요했습니다.  

일련의 기능을 대응하고 확장성을 갖추기 위해 모든 HID 및 입력 이벤트를 지원 가능하게 확장할 수 있도록(_다시 말해 실제로는 구현되지 않았습니다._) 이 코드를 추가하였습니다.

## 설계

### 키 이벤트 및 상태 관리

HID 이벤트로서 발생하는 상태는 `HIDExpressionManagement`가 관리합니다. 예를 들어, 포커스 모드의 최종 상태는 이 클래스가 관리하며, 다른 코드에서 이 클래스를 통해 상태를 참조할 수 있습니다.  
_이 클래스는 싱글톤 객체를 자동 생성하므로, 실제로는 싱글톤 객체를 통해 참조합니다._  
```cs
HIDExpressionManagement.instance;
```

하지만 `HIDExpressionManagement`는 상태 데이터를 관리하는 데 집중하므로, 각 상태에 따른 대응은 `HIDExpressionManager`가 수행합니다. 다시 말해 `HIDExpressionMangement`는 데이터 스토리지이고, `HIDExpressionManager`는 핸들러에 가깝습니다.

### 키 설정값 관리

`HIDExpressionManager`가 HID 입력 이벤트를 감지하는데 활용할 데이터로 `HIDInteractionInvokerConfig`, `HIDInteractionInvokerConfigHolder`가 있습니다. `HIDInteractionInvokerConfig`는 소위 말해, 키 세팅을 지원하기 위한 구조체입니다.  

하지만 `HIDInteractionInvokerConfig`는 구조체이므로, 전역적으로 참조하기 위해 `HIDInteractionConfigHolder`의 싱글톤 객체를 사용해야 합니다.

실제로는 아래와 같이 `HIDInteractionInvokerConfig`를 호출할 수 있습니다.
```cs
HIDInteractionInvokerConfigHolder.instance;
```

이와 같이 구조체와 객체를 구분함으로서, 직렬화할 키 세팅 필드의 범위를 명확하게 구분할 수 있습니다. 이후에 키 세팅 필드를 직렬화 하는 방향으로 개발이 진행된다면, `HIDInteractionInvokerConfig`만을 직렬화하면 됩니다.  
_최초 커밋 시점에서는 이미 `HIDInteractionInvokerConfig`에 `[Serializable]` 처리를 해두었습니다._

최초 커밋 시점의 코드 기준으로, `HIDInteractionInvokerConfig`의 값은 `HIDInteractionInvokerDefaults`에 의해 결정됩니다. _만약 이후에 키 세팅을 저장하고 로드할 수 있도록 개발이 진행된다면, `HIDInteractionInvokerConfig`는 세팅이 제대로 로드되지 않을 때에만 사용할 수 있도록 수정되어야 합니다._

## HIDExpressionManager 프리팹

`HIDExpressionManager` 클래스를 실제로 사용하는 방법 중 하나로서 추가하였습니다.  

_하지만 파라미터 설정이 존재하지 않으므로, 실제로는 게임 오브젝트 컴포넌트로서 등록하기만 하면 됩니다._
</details>
</summary>